### PR TITLE
Bug/#15908 cannot specify management interface

### DIFF
--- a/resources/scripts/rb_init_conf.rb
+++ b/resources/scripts/rb_init_conf.rb
@@ -271,6 +271,7 @@ unless network.nil? # network will not be defined in cloud deployments
       end
 
       if Config_utils.net_get_device_bypass_master(dev)
+        # this port is a bypass master ... need to set to standard nic
         system("bpctl_util #{dev} set_std_nic on")
       end
     }

--- a/resources/scripts/rb_init_conf.rb
+++ b/resources/scripts/rb_init_conf.rb
@@ -240,13 +240,12 @@ unless network.nil? # network will not be defined in cloud deployments
   end
 
   # Configure NETWORK 
-  management_interface = init_conf['network']['management_interface'] if init_conf['network'] && init_conf['network']['management_interface']
   network['interfaces'].each do |iface|
     dev = iface['device']
     iface_mode = iface['mode']
 
     open("/etc/sysconfig/network-scripts/ifcfg-#{dev}", 'w') { |f|
-      # Configuración común a todas las interfaces
+      # Commom configuration to all interfaces
       f.puts "BOOTPROTO=#{iface_mode}"
       f.puts "DEVICE=#{dev}"
       f.puts "ONBOOT=yes"

--- a/resources/scripts/rb_init_conf.rb
+++ b/resources/scripts/rb_init_conf.rb
@@ -258,7 +258,11 @@ unless network.nil? # network will not be defined in cloud deployments
           f.puts "IPADDR=#{iface['ip']}" if iface['ip']
           f.puts "NETMASK=#{iface['netmask']}" if iface['netmask']
           f.puts "GATEWAY=#{iface['gateway']}" if iface['gateway']
-          f.puts "DEFROUTE=yes" if dev == management_interface
+          if dev == management_interface
+            f.puts "DEFROUTE=yes"
+          else
+            f.puts "DEFROUTE=no"
+          end
         else
           p err_msg = "Invalid network configuration for device #{dev}. Please review #{INITCONF} file"
           exit 1

--- a/resources/scripts/rb_setup_wizard.rb
+++ b/resources/scripts/rb_setup_wizard.rb
@@ -162,6 +162,33 @@ EOF
         general_conf["network"].delete("dns")
     end
 end
+##############################
+# INTERFACES  CONFIGURATION  #
+##############################
+if general_conf["network"]["interfaces"].size > 1
+    static_interface = general_conf["network"]["interfaces"].find { |i| i["mode"] == "static" }
+    dhcp_interfaces = general_conf["network"]["interfaces"].select { |i| i["mode"] == "dhcp" }
+
+    if static_interface && dhcp_interfaces.size >= 1
+        general_conf["network"]["management_interface"] = static_interface["device"]
+    else
+        interface_options = general_conf["network"]["interfaces"].map { |i| [i["device"]] }
+        text = <<EOF
+You have multiple network interfaces configured.
+Please select one to be used as the management interface.
+EOF
+        dialog = MRDialog.new
+        dialog.clear = true
+        dialog.title = "Select Management Interface"
+        management_iface = dialog.menu(text, interface_options, 10, 50)
+
+        if management_iface.nil? || management_iface.empty?
+            cancel_wizard
+        else
+            general_conf["network"]["management_interface"] = management_iface
+        end
+    end
+end
 
 ##########################
 # IPMI    CONFIGURATION  #


### PR DESCRIPTION
## Overview
This MR implements an enhanced mechanism for selecting the management interface during network configuration.

## Changes Made

- **`rb_setup_wizard.rb`**:
  - Added logic to automatically select a static interface as the management interface if exactly one is present and others are DHCP.
  - Provided an option for the user to choose the management interface if the automatic selection criteria are not met.

- **`rb_init.rconf.rb`**:
  - Implemented initialization of the `management_interface` from `init_conf['network']` if available. This ensures the chosen management interface is set as the default interface during the setup process.
