### PR TITLE
Feature/add rename network interfaces to setup wizard

### DIFF
--- a/resources/bin/rb_rename_network_interfaces.sh
+++ b/resources/bin/rb_rename_network_interfaces.sh
@@ -1,0 +1,36 @@
+#!/bin/bash
+
+#######################################################################
+# Copyright (c) 2024 ENEO Tecnología S.L.
+# This file is part of redBorder.
+# redBorder is free software: you can redistribute it and/or modify
+# it under the terms of the GNU Affero General Public License License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+# redBorder is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU Affero General Public License License for more details.
+# You should have received a copy of the GNU Affero General Public License License
+# along with redBorder. If not, see <http://www.gnu.org/licenses/>.
+######################################################################
+
+counter=0
+
+interfaces=$(ls /sys/class/net | grep -v lo)
+
+udev_rules_file="/etc/udev/rules.d/10-persistent-net.rules"
+
+echo "" > $udev_rules_file
+
+for interface in $interfaces; do
+    mac_address=$(cat /sys/class/net/$interface/address)
+    new_name="eth$counter"
+
+    ((counter++))
+
+    echo "SUBSYSTEM==\"net\", ACTION==\"add\", ATTR{address}==\"$mac_address\", NAME=\"$new_name\"" >> $udev_rules_file
+    echo "Interface $interface will be renamed to $new_name"
+done
+
+echo "Please reboot the system to apply the changes."

--- a/resources/lib/rb_config_utils.rb
+++ b/resources/lib/rb_config_utils.rb
@@ -421,6 +421,28 @@ module Config_utils
     return { :ip => net_ipmi_ip, :netmask => net_ipmi_netmask, :gateway => net_ipmi_gateway}
   end
 
+  def self.get_network_interfaces
+    interfaces = []
+    `ip link show`.each_line do |line|
+      if line =~ /^\d+: ([^:]+):/
+        interfaces << $1 if $1 != "lo"
+      end
+    end
+    interfaces
+  end
+
+  def self.modern_interface?(interface)
+    old_pattern = /^eth\d+/
+    !(interface =~ old_pattern)
+  end
+
+  def self.need_to_rename_network_interfaces?
+    interfaces = get_network_interfaces
+    modern_interfaces = interfaces.select { |interface| modern_interface?(interface) }
+
+    modern_interfaces.any?
+  end
+
 end
 
 ## vim:ts=4:sw=4:expandtab:ai:nowrap:formatoptions=croqln:

--- a/resources/scripts/rb_setup_wizard.rb
+++ b/resources/scripts/rb_setup_wizard.rb
@@ -102,6 +102,54 @@ unless yesno # yesno is "yes" -> true
     cancel_wizard
 end
 
+##############################
+# RENAME NETWORK INTERFACES  #
+##############################
+if Config_utils.need_to_rename_network_interfaces?
+  text = <<EOF
+
+  We have detected that your system has modern network interface names (e.g., enp0s3, wlp2s0) instead of the traditional names (e.g., eth0, eth1).
+
+  Renaming network interfaces can help maintain consistency and compatibility with certain applications and scripts that expect the older naming convention.
+
+  Would you like to rename your network interfaces to the traditional naming convention?
+
+  Note: This process will modify system configuration files and may require a system restart to apply the changes.
+
+EOF
+
+  dialog = MRDialog.new
+  dialog.clear = true
+  dialog.title = "Rename Network Interfaces"
+  dialog.cancel_label = "SKIP"
+  dialog.no_label = "SKIP"
+  yesno = dialog.yesno(text,0,0)
+  if yesno
+    text = <<EOF
+
+    You have chosen to rename your network interfaces. Please confirm your choice.
+
+EOF
+
+    dialog = MRDialog.new
+    dialog.clear = true
+    dialog.title = "Confirm configuration"
+    yesno = dialog.yesno(text,0,0)
+
+    unless yesno # yesno is "yes" -> true
+        cancel_wizard
+    end
+    command = "#{ENV['RBBIN']}/rb_rename_network_interfaces.sh"
+
+    dialog = MRDialog.new
+    dialog.clear = false
+    dialog.title = "Applying configuration"
+    dialog.prgbox(command,20,100, "Executing rb_rename_network_interfaces")
+    system("reboot")
+  end
+
+end
+
 ##########################
 # NETWORK CONFIGURATION  #
 ##########################


### PR DESCRIPTION
- New option in setup wizard of IPS to rename network interfaces following the tradicional naming system (ethX)